### PR TITLE
fix:修复配置不生效问题

### DIFF
--- a/src/JinianNet.JNTemplate/Engine.cs
+++ b/src/JinianNet.JNTemplate/Engine.cs
@@ -69,6 +69,7 @@ namespace JinianNet.JNTemplate
             var conf = Configuration.EngineConfig.CreateDefault();
             var score = new VariableScope(null, Current.Options.TypeDetectPattern);
             action?.Invoke(conf, score);
+            Current.Configure(conf, score);
         }
 
         /// <summary>


### PR DESCRIPTION
原因：由于void Configure(Action<IConfig, VariableScope> action) 中未调用Current.Configure(conf, score);导致配置并示生效。
解决方法：调用Current.Configure(conf, score);生效配置